### PR TITLE
Docker-based development environment

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -9,5 +9,3 @@ RUN . "$NVM_DIR/nvm.sh" && \
     nvm alias default v${NODE_VERSION}
 ENV PATH="/root/.nvm/versions/node/v${NODE_VERSION}/bin/:${PATH}"
 RUN npm install -g yarn
-
-ENV DATABASE_URL=postgresql://db

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,13 @@
+FROM ruby:3.1-bullseye
+ENV NODE_VERSION=17.5.0
+
+RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.0/install.sh | bash
+ENV NVM_DIR=/root/.nvm
+RUN . "$NVM_DIR/nvm.sh" && \
+    nvm install ${NODE_VERSION} && \
+    nvm use v${NODE_VERSION} && \
+    nvm alias default v${NODE_VERSION}
+ENV PATH="/root/.nvm/versions/node/v${NODE_VERSION}/bin/:${PATH}"
+RUN npm install -g yarn
+
+ENV DATABASE_URL=postgresql://db

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,28 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.222.0/containers/docker-existing-docker-compose
+// If you want to run as a non-root user in the container, see .devcontainer/docker-compose.yml.
+{
+	"name": "8-Bit Bunny",
+
+	// Update the 'dockerComposeFile' list if you have more compose files or use different names.
+	// The .devcontainer/docker-compose.yml file contains any overrides you need/want to make.
+	"dockerComposeFile": [ "docker-compose.yml" ],
+
+	// The 'service' property is the name of the service for the container that VS Code should
+	// use. Update this value and .devcontainer/docker-compose.yml to the real service name.
+	"service": "app",
+
+	// The optional 'workspaceFolder' property is the path VS Code should open by default when
+	// connected. This is typically a file mount in .devcontainer/docker-compose.yml
+	"workspaceFolder": "/workspace",
+
+	// Set *default* container specific settings.json values on container create.
+	"settings": {},
+
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [],
+
+	"forwardPorts": [5050],
+
+	"postCreateCommand": "/workspace/bin/setup"
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,16 @@
+services:
+  db:
+    image: postgres
+    volumes: [../tmp/db:/var/lib/postgresql/data]
+    environment:
+      POSTGRES_HOST_AUTH_METHOD: trust
+      POSTGRES_USER: postgres
+
+  app:
+    build: .
+    command: sleep infinity
+    depends_on: [db]
+    environemnt:
+      DATABASE_URL: postgresql://db
+    network_mode: service:db
+    volumes: [..:/workspace:cached]

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     build: .
     command: sleep infinity
     depends_on: [db]
-    environemnt:
+    environment:
       DATABASE_URL: postgresql://db
     network_mode: service:db
     volumes: [..:/workspace:cached]

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+    "recommendations": [
+        "ms-vscode-remote.remote-containers",
+        "sianglim.slim"
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This Rails app is used to power our camps registration system at [burn.8bitbunny
 
 ### Develop on macOS
 1. Use [Homebrew](https://brew.sh) to install rbenv, PosgreSQL, and other native dependencies:
+
     ```
     $ brew install rbenv vips postgresql
     ```

--- a/README.md
+++ b/README.md
@@ -4,20 +4,36 @@
 
 This Rails app is used to power our camps registration system at [burn.8bitbunny.com](https://burn.8bitbunny.com/). Our goal is to test it in 2022 and then roll it out as a SasS product for 2023.
 
-### Start
+### Develop on macOS
+1. Use [Homebrew](https://brew.sh) to install rbenv, PosgreSQL, and other native dependencies:
+    ```
+    $ brew install rbenv vips postgresql
+    ```
+2. Run the `./bin/setup` script to install gems and NPM dependencies, and create the database.
 
+### Develop on Windows
+1. [Install Docker Desktop using WSL 2 backend](https://docs.docker.com/desktop/windows/wsl/)
+2. [Install Visual Studio Code](https://code.visualstudio.com/)
+3. Make sure to disable the Git `autocrlf` option before cloning the repo, otherwise all the files will be full of CRLFs and won't work.
+    ```
+    PS C:\> git config --global core.autocrlf false
+    ```
+   If you've already cloned the repo with CRLFs, it's probably best to delete it and start over.
+
+4. In Visual Studio Code:
+   1. [Install Remote - Containers Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)
+   2. Press `Ctrl`+`Shift`+`P` to open the VS Code command line
+   3. Type `Remote-Containers: Open Folder in Container...`
+   4. Open the repository folder. The `bin/setup` script will run automatically in the container, installing all gems and creating the database.
+
+### Start
+Run the following command and open http://localhost:5050/.
 ```
-$ foreman start
+$ ./bin/dev
 ```
 
 ### Deploy
 
 ```
 $ git push heroku
-```
-
-### Install Dependencies
-
-```
-$ brew install rbenv vips postgresql
 ```

--- a/bin/setup
+++ b/bin/setup
@@ -8,9 +8,12 @@ def system!(*args)
 end
 
 FileUtils.chdir APP_ROOT do
-  puts "Installing dependencies."
+  puts "Installing Gem dependencies."
   system! "gem install bundler --conservative"
   system("bundle check") || system!("bundle install")
+
+  puts "Installing NPM dependencies."
+  system! "yarn install"
 
   puts "Preparing database."
   system! "bin/rails db:prepare"

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,7 +1,6 @@
 default: &default
-  adapter: postgresql
   encoding: unicode
-  host: localhost
+  url: <%= ENV.fetch("DATABASE_URL", "postgresql://localhost") %>
   pool: <%= ENV.fetch("DB_MAX_POOL", 7) %>
   username: postgres
   password:
@@ -16,5 +15,4 @@ test:
 
 production:
   <<: *default
-  url: <%= ENV["DATABASE_URL"] %>
   pool: <%= ENV.fetch("DB_MAX_POOL", 10) %>


### PR DESCRIPTION
Adds a VS Code devcontainer configuration to easily develop the app on Windows. I see no reason why it shouldn't work on macOS and Linux hosts (or without VS Code, in just Docker Compose), but I haven't tried it.

Runs a Debian Bullseye Ruby 3.1.1 container with Node 15 added, and a Postgres container for the DB.

I modified the default database configuration to highlight that the `DATABASE_URL` env variable is also used in development now. Hope I didn't break anything.

Also added `yarn install` to the `bin/setup` script. Not sure what the correct way of starting the app should be. I updated the README to mention the `bin/dev` script, but if we want to use `foreman` directly, we should probably install it from the setup script and delete the dev script :) 